### PR TITLE
[WIP] wait for static ip allocation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -84,7 +84,7 @@ RELEASE_REGISTRY := gcr.io/cluster-api-provider-vsphere/release
 RELEASE_CONTROLLER_IMG := $(RELEASE_REGISTRY)/$(IMAGE_NAME)
 
 # Development Docker variables
-DEV_REGISTRY ?= gcr.io/spectro-common-dev/${USER}
+DEV_REGISTRY ?= gcr.io/$(shell gcloud config get-value project)
 DEV_CONTROLLER_IMG ?= $(DEV_REGISTRY)/vsphere-$(IMAGE_NAME)
 DEV_TAG ?= dev
 DEV_MANIFEST_IMG := $(DEV_CONTROLLER_IMG)-$(ARCH)

--- a/Makefile
+++ b/Makefile
@@ -84,7 +84,7 @@ RELEASE_REGISTRY := gcr.io/cluster-api-provider-vsphere/release
 RELEASE_CONTROLLER_IMG := $(RELEASE_REGISTRY)/$(IMAGE_NAME)
 
 # Development Docker variables
-DEV_REGISTRY ?= gcr.io/$(shell gcloud config get-value project)
+DEV_REGISTRY ?= gcr.io/spectro-common-dev/${USER}
 DEV_CONTROLLER_IMG ?= $(DEV_REGISTRY)/vsphere-$(IMAGE_NAME)
 DEV_TAG ?= dev
 DEV_MANIFEST_IMG := $(DEV_CONTROLLER_IMG)-$(ARCH)

--- a/controllers/vspherevm_controller.go
+++ b/controllers/vspherevm_controller.go
@@ -362,21 +362,13 @@ func (r vmReconciler) reconcileNormal(ctx *context.VMContext) (reconcile.Result,
 }
 
 func (r vmReconciler) isWaitingForStaticIPAllocation(ctx *context.VMContext) bool {
-	// Requeue if the two DHCP flags are set to false
-	// and no static IP is set in the IPAddrs.
 	waitForIP := false
 	devices := ctx.VSphereVM.Spec.Network.Devices
 
 	for _, dev := range devices {
-		// If DHCP is set for any of the devices,
-		// assume DHCP as the default allocation type.
-		if dev.DHCP4 || dev.DHCP6 {
-			return false
-		} else {
-			if len(dev.IPAddrs) == 0 {
-				// Static IP is not available yet
-				waitForIP = true
-			}
+		if !dev.DHCP4 && !dev.DHCP6 && len(dev.IPAddrs) == 0 {
+			// Static IP is not available yet
+			waitForIP = true
 		}
 	}
 

--- a/controllers/vspherevm_controller.go
+++ b/controllers/vspherevm_controller.go
@@ -366,7 +366,7 @@ func (r vmReconciler) isWaitingForStaticIPAllocation(ctx *context.VMContext) boo
 		if dev.DHCP4 || dev.DHCP6 {
 			return false
 		} else {
-			if (!dev.DHCP4 && len(dev.Gateway4) <= 0) || (!dev.DHCP6 && len(dev.Gateway6) <= 0) || len(dev.IPAddrs) <= 0 {
+			if len(dev.IPAddrs) == 0 {
 				// Static IP is not available yet
 				waitForIP = true
 			}

--- a/controllers/vspherevm_controller.go
+++ b/controllers/vspherevm_controller.go
@@ -308,7 +308,7 @@ func (r vmReconciler) reconcileNormal(ctx *context.VMContext) (reconcile.Result,
 	var vmService services.VirtualMachineService = &govmomi.VMService{}
 
 	if r.isWaitingForStaticIPAllocation(ctx) {
-		r.Logger.Info("vm is waiting for static ip to be available", "namespace", ctx.VSphereVM.Namespace, "name", ctx.VSphereVM.Name)
+		ctx.Logger.Info("vm is waiting for static ip to be available")
 		return reconcile.Result{}, nil
 	}
 
@@ -366,7 +366,7 @@ func (r vmReconciler) isWaitingForStaticIPAllocation(ctx *context.VMContext) boo
 		if dev.DHCP4 || dev.DHCP6 {
 			return false
 		} else {
-			if len(dev.Gateway4) <= 0 || len(dev.IPAddrs) <= 0 {
+			if (!dev.DHCP4 && len(dev.Gateway4) <= 0) || (!dev.DHCP6 && len(dev.Gateway6) <= 0) || len(dev.IPAddrs) <= 0 {
 				// Static IP is not available yet
 				waitForIP = true
 			}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:
CAPV has support to assign static IP to VSphereMachine, but the static IP itself can be assigned by different means. For eg., one such implementation can be using a third party controller to modify VSphereMachine to add static IP after the object is created.
Irrespective of the implementation choice to assign static IP, if DHCP is disabled, the CAPV controllers have to wait for static IPs to be available and then continue to provision VMs.  
Currently, if both DHCP4 and DHCP6 are disabled and a staticIP is set in HAProxyLB's Network.Devices.IpAddrs, the VSphereVM for HAProxyLB goes to 'Ready' without any IPAddress in the status. The HAProxyLB then never goes to 'Ready' since its indefinitely waiting for the VSphereVM's IPAddress.
This PR checks if both DHCP4 and DHCP6 are disabled for all network devices(NetworkSpec.devices) and  if there is no static IP provided in the IPAddrs list, then the CAPV controllers  wait for the static IP to be available/assigned.
This PR also makes sure the VSphereVM is set to 'Ready' only after network is reconciled. 

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```