### PR TITLE
add keep alive support for session.TagManager rest client

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -91,9 +91,9 @@ RELEASE_REGISTRY := gcr.io/cluster-api-provider-vsphere/release
 RELEASE_CONTROLLER_IMG := $(RELEASE_REGISTRY)/$(IMAGE_NAME)
 
 # Development Docker variables
-DEV_REGISTRY ?= gcr.io/spectro-images-public/release/cluster-api-provider-vsphere
+DEV_REGISTRY ?= gcr.io/spectro-dev-public/release/cluster-api-provider-vsphere
 DEV_CONTROLLER_IMG ?= $(DEV_REGISTRY)/cluster-api-vsphere-controller
-DEV_TAG ?= spectro-v0.8.1-20220321
+DEV_TAG ?= spectro-v0.8.1-20220504
 DEV_MANIFEST_IMG := $(DEV_CONTROLLER_IMG)
 
 # Set build time variables including git version details

--- a/controllers/sessio_test.go
+++ b/controllers/sessio_test.go
@@ -1,0 +1,233 @@
+package controllers
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/onsi/gomega"
+	"github.com/onsi/gomega/gbytes"
+	"github.com/vmware/govmomi/simulator"
+	"k8s.io/klog/v2/klogr"
+	"sigs.k8s.io/cluster-api-provider-vsphere/pkg/session"
+	"sigs.k8s.io/cluster-api-provider-vsphere/test/helpers"
+	log2 "sigs.k8s.io/controller-runtime/pkg/log"
+
+	// run init func to register the tagging API endpoints
+	_ "github.com/vmware/govmomi/vapi/simulator"
+)
+
+func TestGetSession(t *testing.T) {
+	g := gomega.NewWithT(t)
+	log := klogr.New()
+
+	log2.SetLogger(log)
+
+	os.Setenv("GOVC_BIN_PATH", "/usr/local/bin/govc")
+	simulator.SessionIdleTimeout = 1 * time.Second
+
+	model := simulator.VPX()
+	model.Cluster = 2
+
+	simr, err := helpers.VCSimBuilder().
+		WithModel(model).Build()
+	if err != nil {
+		t.Fatalf("failed to create VC simulator")
+	}
+	defer simr.Destroy()
+
+	params := session.NewParams().
+		WithServer(simr.ServerURL().Host).
+		WithUserInfo(simr.Username(), simr.Password())
+
+	// Get first session
+	s, err := session.GetOrCreate(context.Background(), params)
+	g.Expect(err).ToNot(gomega.HaveOccurred())
+	g.Expect(s).ToNot(gomega.BeNil())
+	AssetSessionCountEqualTo(g, simr, 1)
+
+	// Get session key
+	sessionInfo, err := s.SessionManager.UserSession(context.Background())
+	g.Expect(sessionInfo).ToNot(gomega.BeNil())
+	firstSession := sessionInfo.Key
+
+	// remove session expect no session
+	g.Expect(s.TagManager.Logout(context.Background())).To(gomega.Succeed())
+	g.Expect(simr.Run(fmt.Sprintf("session.rm %s", firstSession))).To(gomega.Succeed())
+	AssetSessionCountEqualTo(g, simr, 0)
+
+	// request sesion again should be a new and different session
+	s, err = session.GetOrCreate(context.Background(), params)
+	g.Expect(err).ToNot(gomega.HaveOccurred())
+	g.Expect(s).ToNot(gomega.BeNil())
+
+
+	// Get session info, session key should be different from
+	// last session
+	sessionInfo, err = s.SessionManager.UserSession(context.Background())
+	g.Expect(sessionInfo).ToNot(gomega.BeNil())
+	g.Expect(sessionInfo.Key).ToNot(gomega.BeEquivalentTo(firstSession))
+	AssetSessionCountEqualTo(g, simr, 1)
+}
+
+func sessionCount(stdout *gbytes.Buffer) (int, error) {
+	buf := make([]byte, 1024)
+	count := 0
+	lineSep := []byte("infrastructure.cluster.x-k8s.io/v1alpha4")
+
+	for {
+		c, err := stdout.Read(buf)
+		count += bytes.Count(buf[:c], lineSep)
+
+		switch {
+		case err == io.EOF:
+			return count, nil
+
+		case err != nil:
+			return count, err
+		}
+	}
+}
+
+func AssetSessionCountEqualTo(g *gomega.WithT, simr *helpers.Simulator, count int) {
+	stdout := gbytes.NewBuffer()
+	g.Expect(simr.Run("session.ls", stdout)).To(gomega.Succeed())
+	g.Expect(sessionCount(stdout)).To(gomega.BeNumerically("==", count))
+}
+
+func TestGetSessionWithKeepAlive(t *testing.T) {
+	g := gomega.NewWithT(t)
+	log := klogr.New()
+
+	log2.SetLogger(log)
+
+	os.Setenv("GOVC_BIN_PATH", "/usr/local/bin/govc")
+	simulator.SessionIdleTimeout = 1 * time.Second
+
+	model := simulator.VPX()
+	model.Cluster = 2
+
+	simr, err := helpers.VCSimBuilder().
+		WithModel(model).Build()
+	if err != nil {
+		t.Fatalf("failed to create VC simulator")
+	}
+	defer simr.Destroy()
+
+	params := session.NewParams().
+		WithServer(simr.ServerURL().Host).
+		WithUserInfo(simr.Username(), simr.Password()).
+		WithFeatures(session.Feature{EnableKeepAlive: true})
+
+
+	// Get first Session
+	s, err := session.GetOrCreate(context.Background(), params)
+	g.Expect(err).ToNot(gomega.HaveOccurred())
+	g.Expect(s).ToNot(gomega.BeNil())
+	AssetSessionCountEqualTo(g, simr, 1)
+
+	// Get session key
+	sessionInfo, err := s.SessionManager.UserSession(context.Background())
+	g.Expect(sessionInfo).ToNot(gomega.BeNil())
+	firstSession := sessionInfo.Key
+
+	// Get the session again
+	// as keep alive is enabled and session is
+	// not expired we must get the same cached session
+	s, err = session.GetOrCreate(context.Background(), params)
+	g.Expect(err).ToNot(gomega.HaveOccurred())
+	g.Expect(s).ToNot(gomega.BeNil())
+	sessionInfo, err = s.SessionManager.UserSession(context.Background())
+	g.Expect(sessionInfo).ToNot(gomega.BeNil())
+	g.Expect(sessionInfo.Key).To(gomega.BeEquivalentTo(firstSession))
+	AssetSessionCountEqualTo(g, simr, 1)
+
+
+	// Try to remove vim session
+	s.Logout(context.Background())
+
+
+	// after logging out old session must be deleted and
+	// we must get a new different session
+	// total session count must remain 1
+	s, err = session.GetOrCreate(context.Background(), params)
+	g.Expect(err).ToNot(gomega.HaveOccurred())
+	g.Expect(s).ToNot(gomega.BeNil())
+	sessionInfo, err = s.SessionManager.UserSession(context.Background())
+	g.Expect(sessionInfo).ToNot(gomega.BeNil())
+	g.Expect(sessionInfo.Key).ToNot(gomega.BeEquivalentTo(firstSession))
+	AssetSessionCountEqualTo(g, simr, 1)
+}
+
+func TestGetSessionWithKeepAliveTagManagerLogout(t *testing.T) {
+	g := gomega.NewWithT(t)
+	log := klogr.New()
+
+	log2.SetLogger(log)
+
+	os.Setenv("GOVC_BIN_PATH", "/usr/local/bin/govc")
+	simulator.SessionIdleTimeout = 1 * time.Second
+
+	model := simulator.VPX()
+	model.Cluster = 2
+
+	simr, err := helpers.VCSimBuilder().
+		WithModel(model).Build()
+	if err != nil {
+		t.Fatalf("failed to create VC simulator")
+	}
+	defer simr.Destroy()
+
+	params := session.NewParams().
+		WithServer(simr.ServerURL().Host).
+		WithUserInfo(simr.Username(), simr.Password()).
+		WithFeatures(session.Feature{EnableKeepAlive: true, KeepAliveDuration: 2 * time.Second})
+
+
+	// Get first session
+	s, err := session.GetOrCreate(context.Background(), params)
+	g.Expect(err).ToNot(gomega.HaveOccurred())
+	g.Expect(s).ToNot(gomega.BeNil())
+	sessionInfo, err := s.SessionManager.UserSession(context.Background())
+	g.Expect(sessionInfo).ToNot(gomega.BeNil())
+	sessionKey := sessionInfo.Key
+	AssetSessionCountEqualTo(g, simr, 1)
+
+	// wait enough time so the session is expired
+	// as KeepAliveDuration 2 seconds > SessionIdleTimeout 1 second
+	time.Sleep(5 * time.Second)
+	AssetSessionCountEqualTo(g, simr, 0)
+
+	// Get session again
+	// as session is deleted we must get new session
+	// old session is expected to be cleaned up so count == 1
+	s, err = session.GetOrCreate(context.Background(), params)
+	g.Expect(err).ToNot(gomega.HaveOccurred())
+	g.Expect(s).ToNot(gomega.BeNil())
+	sessionInfo, err = s.SessionManager.UserSession(context.Background())
+	g.Expect(err).ToNot(gomega.HaveOccurred())
+	g.Expect(sessionInfo).ToNot(gomega.BeNil())
+	g.Expect(sessionInfo.Key).ToNot(gomega.BeEquivalentTo(sessionKey))
+	sessionKey = sessionInfo.Key
+	AssetSessionCountEqualTo(g, simr, 1)
+
+
+	// wait enough time so the session is expired
+	// as KeepAliveDuration 2 seconds > SessionIdleTimeout 1 second
+	time.Sleep(5 * time.Second)
+	AssetSessionCountEqualTo(g, simr, 0)
+
+
+	s, err = session.GetOrCreate(context.Background(), params)
+	g.Expect(err).ToNot(gomega.HaveOccurred())
+	g.Expect(s).ToNot(gomega.BeNil())
+	sessionInfo, err = s.SessionManager.UserSession(context.Background())
+	g.Expect(err).ToNot(gomega.HaveOccurred())
+	g.Expect(sessionInfo).ToNot(gomega.BeNil())
+	g.Expect(sessionInfo.Key).ToNot(gomega.BeEquivalentTo(sessionKey))
+	AssetSessionCountEqualTo(g, simr, 1)
+}

--- a/controllers/sessio_test.go
+++ b/controllers/sessio_test.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"os"
 	"testing"
 	"time"
 
@@ -13,9 +12,10 @@ import (
 	"github.com/onsi/gomega/gbytes"
 	"github.com/vmware/govmomi/simulator"
 	"k8s.io/klog/v2/klogr"
+	"sigs.k8s.io/cluster-api-provider-vsphere/api/v1alpha4"
 	"sigs.k8s.io/cluster-api-provider-vsphere/pkg/session"
 	"sigs.k8s.io/cluster-api-provider-vsphere/test/helpers"
-	log2 "sigs.k8s.io/controller-runtime/pkg/log"
+	ctrllog "sigs.k8s.io/controller-runtime/pkg/log"
 
 	// run init func to register the tagging API endpoints
 	_ "github.com/vmware/govmomi/vapi/simulator"
@@ -24,11 +24,7 @@ import (
 func TestGetSession(t *testing.T) {
 	g := gomega.NewWithT(t)
 	log := klogr.New()
-
-	log2.SetLogger(log)
-
-	os.Setenv("GOVC_BIN_PATH", "/usr/local/bin/govc")
-	simulator.SessionIdleTimeout = 1 * time.Second
+	ctrllog.SetLogger(log)
 
 	model := simulator.VPX()
 	model.Cluster = 2
@@ -42,7 +38,7 @@ func TestGetSession(t *testing.T) {
 
 	params := session.NewParams().
 		WithServer(simr.ServerURL().Host).
-		WithUserInfo(simr.Username(), simr.Password())
+		WithUserInfo(simr.Username(), simr.Password()).WithDatacenter("*")
 
 	// Get first session
 	s, err := session.GetOrCreate(context.Background(), params)
@@ -52,6 +48,7 @@ func TestGetSession(t *testing.T) {
 
 	// Get session key
 	sessionInfo, err := s.SessionManager.UserSession(context.Background())
+	g.Expect(err).ToNot(gomega.HaveOccurred())
 	g.Expect(sessionInfo).ToNot(gomega.BeNil())
 	firstSession := sessionInfo.Key
 
@@ -65,19 +62,19 @@ func TestGetSession(t *testing.T) {
 	g.Expect(err).ToNot(gomega.HaveOccurred())
 	g.Expect(s).ToNot(gomega.BeNil())
 
-
 	// Get session info, session key should be different from
 	// last session
 	sessionInfo, err = s.SessionManager.UserSession(context.Background())
 	g.Expect(sessionInfo).ToNot(gomega.BeNil())
+	g.Expect(err).ToNot(gomega.HaveOccurred())
 	g.Expect(sessionInfo.Key).ToNot(gomega.BeEquivalentTo(firstSession))
 	AssetSessionCountEqualTo(g, simr, 1)
 }
 
-func sessionCount(stdout *gbytes.Buffer) (int, error) {
+func sessionCount(stdout io.Reader) (int, error) {
 	buf := make([]byte, 1024)
 	count := 0
-	lineSep := []byte("infrastructure.cluster.x-k8s.io/v1alpha4")
+	lineSep := []byte(v1alpha4.GroupVersion.String())
 
 	for {
 		c, err := stdout.Read(buf)
@@ -102,11 +99,7 @@ func AssetSessionCountEqualTo(g *gomega.WithT, simr *helpers.Simulator, count in
 func TestGetSessionWithKeepAlive(t *testing.T) {
 	g := gomega.NewWithT(t)
 	log := klogr.New()
-
-	log2.SetLogger(log)
-
-	os.Setenv("GOVC_BIN_PATH", "/usr/local/bin/govc")
-	simulator.SessionIdleTimeout = 1 * time.Second
+	ctrllog.SetLogger(log)
 
 	model := simulator.VPX()
 	model.Cluster = 2
@@ -121,8 +114,8 @@ func TestGetSessionWithKeepAlive(t *testing.T) {
 	params := session.NewParams().
 		WithServer(simr.ServerURL().Host).
 		WithUserInfo(simr.Username(), simr.Password()).
-		WithFeatures(session.Feature{EnableKeepAlive: true})
-
+		WithFeatures(session.Feature{EnableKeepAlive: true}).
+		WithDatacenter("*")
 
 	// Get first Session
 	s, err := session.GetOrCreate(context.Background(), params)
@@ -132,6 +125,7 @@ func TestGetSessionWithKeepAlive(t *testing.T) {
 
 	// Get session key
 	sessionInfo, err := s.SessionManager.UserSession(context.Background())
+	g.Expect(err).ToNot(gomega.HaveOccurred())
 	g.Expect(sessionInfo).ToNot(gomega.BeNil())
 	firstSession := sessionInfo.Key
 
@@ -142,14 +136,13 @@ func TestGetSessionWithKeepAlive(t *testing.T) {
 	g.Expect(err).ToNot(gomega.HaveOccurred())
 	g.Expect(s).ToNot(gomega.BeNil())
 	sessionInfo, err = s.SessionManager.UserSession(context.Background())
+	g.Expect(err).ToNot(gomega.HaveOccurred())
 	g.Expect(sessionInfo).ToNot(gomega.BeNil())
 	g.Expect(sessionInfo.Key).To(gomega.BeEquivalentTo(firstSession))
 	AssetSessionCountEqualTo(g, simr, 1)
 
-
 	// Try to remove vim session
-	s.Logout(context.Background())
-
+	g.Expect(s.Logout(context.Background())).To(gomega.Succeed())
 
 	// after logging out old session must be deleted and
 	// we must get a new different session
@@ -158,6 +151,7 @@ func TestGetSessionWithKeepAlive(t *testing.T) {
 	g.Expect(err).ToNot(gomega.HaveOccurred())
 	g.Expect(s).ToNot(gomega.BeNil())
 	sessionInfo, err = s.SessionManager.UserSession(context.Background())
+	g.Expect(err).ToNot(gomega.HaveOccurred())
 	g.Expect(sessionInfo).ToNot(gomega.BeNil())
 	g.Expect(sessionInfo.Key).ToNot(gomega.BeEquivalentTo(firstSession))
 	AssetSessionCountEqualTo(g, simr, 1)
@@ -166,12 +160,9 @@ func TestGetSessionWithKeepAlive(t *testing.T) {
 func TestGetSessionWithKeepAliveTagManagerLogout(t *testing.T) {
 	g := gomega.NewWithT(t)
 	log := klogr.New()
+	ctrllog.SetLogger(log)
 
-	log2.SetLogger(log)
-
-	os.Setenv("GOVC_BIN_PATH", "/usr/local/bin/govc")
 	simulator.SessionIdleTimeout = 1 * time.Second
-
 	model := simulator.VPX()
 	model.Cluster = 2
 
@@ -185,14 +176,15 @@ func TestGetSessionWithKeepAliveTagManagerLogout(t *testing.T) {
 	params := session.NewParams().
 		WithServer(simr.ServerURL().Host).
 		WithUserInfo(simr.Username(), simr.Password()).
-		WithFeatures(session.Feature{EnableKeepAlive: true, KeepAliveDuration: 2 * time.Second})
-
+		WithFeatures(session.Feature{EnableKeepAlive: true, KeepAliveDuration: 2 * time.Second}).WithDatacenter("*")
 
 	// Get first session
 	s, err := session.GetOrCreate(context.Background(), params)
 	g.Expect(err).ToNot(gomega.HaveOccurred())
 	g.Expect(s).ToNot(gomega.BeNil())
+	AssetSessionCountEqualTo(g, simr, 1)
 	sessionInfo, err := s.SessionManager.UserSession(context.Background())
+	g.Expect(err).ToNot(gomega.HaveOccurred())
 	g.Expect(sessionInfo).ToNot(gomega.BeNil())
 	sessionKey := sessionInfo.Key
 	AssetSessionCountEqualTo(g, simr, 1)
@@ -215,12 +207,10 @@ func TestGetSessionWithKeepAliveTagManagerLogout(t *testing.T) {
 	sessionKey = sessionInfo.Key
 	AssetSessionCountEqualTo(g, simr, 1)
 
-
 	// wait enough time so the session is expired
 	// as KeepAliveDuration 2 seconds > SessionIdleTimeout 1 second
 	time.Sleep(5 * time.Second)
 	AssetSessionCountEqualTo(g, simr, 0)
-
 
 	s, err = session.GetOrCreate(context.Background(), params)
 	g.Expect(err).ToNot(gomega.HaveOccurred())

--- a/controllers/sessio_test.go
+++ b/controllers/sessio_test.go
@@ -44,7 +44,7 @@ func TestGetSession(t *testing.T) {
 	s, err := session.GetOrCreate(context.Background(), params)
 	g.Expect(err).ToNot(gomega.HaveOccurred())
 	g.Expect(s).ToNot(gomega.BeNil())
-	AssetSessionCountEqualTo(g, simr, 1)
+	AssertSessionCountEqualTo(g, simr, 1)
 
 	// Get session key
 	sessionInfo, err := s.SessionManager.UserSession(context.Background())
@@ -55,7 +55,7 @@ func TestGetSession(t *testing.T) {
 	// remove session expect no session
 	g.Expect(s.TagManager.Logout(context.Background())).To(gomega.Succeed())
 	g.Expect(simr.Run(fmt.Sprintf("session.rm %s", firstSession))).To(gomega.Succeed())
-	AssetSessionCountEqualTo(g, simr, 0)
+	AssertSessionCountEqualTo(g, simr, 0)
 
 	// request sesion again should be a new and different session
 	s, err = session.GetOrCreate(context.Background(), params)
@@ -68,7 +68,7 @@ func TestGetSession(t *testing.T) {
 	g.Expect(sessionInfo).ToNot(gomega.BeNil())
 	g.Expect(err).ToNot(gomega.HaveOccurred())
 	g.Expect(sessionInfo.Key).ToNot(gomega.BeEquivalentTo(firstSession))
-	AssetSessionCountEqualTo(g, simr, 1)
+	AssertSessionCountEqualTo(g, simr, 1)
 }
 
 func sessionCount(stdout io.Reader) (int, error) {
@@ -90,7 +90,7 @@ func sessionCount(stdout io.Reader) (int, error) {
 	}
 }
 
-func AssetSessionCountEqualTo(g *gomega.WithT, simr *helpers.Simulator, count int) {
+func AssertSessionCountEqualTo(g *gomega.WithT, simr *helpers.Simulator, count int) {
 	stdout := gbytes.NewBuffer()
 	g.Expect(simr.Run("session.ls", stdout)).To(gomega.Succeed())
 	g.Expect(sessionCount(stdout)).To(gomega.BeNumerically("==", count))
@@ -121,7 +121,7 @@ func TestGetSessionWithKeepAlive(t *testing.T) {
 	s, err := session.GetOrCreate(context.Background(), params)
 	g.Expect(err).ToNot(gomega.HaveOccurred())
 	g.Expect(s).ToNot(gomega.BeNil())
-	AssetSessionCountEqualTo(g, simr, 1)
+	AssertSessionCountEqualTo(g, simr, 1)
 
 	// Get session key
 	sessionInfo, err := s.SessionManager.UserSession(context.Background())
@@ -139,7 +139,7 @@ func TestGetSessionWithKeepAlive(t *testing.T) {
 	g.Expect(err).ToNot(gomega.HaveOccurred())
 	g.Expect(sessionInfo).ToNot(gomega.BeNil())
 	g.Expect(sessionInfo.Key).To(gomega.BeEquivalentTo(firstSession))
-	AssetSessionCountEqualTo(g, simr, 1)
+	AssertSessionCountEqualTo(g, simr, 1)
 
 	// Try to remove vim session
 	g.Expect(s.Logout(context.Background())).To(gomega.Succeed())
@@ -154,7 +154,7 @@ func TestGetSessionWithKeepAlive(t *testing.T) {
 	g.Expect(err).ToNot(gomega.HaveOccurred())
 	g.Expect(sessionInfo).ToNot(gomega.BeNil())
 	g.Expect(sessionInfo.Key).ToNot(gomega.BeEquivalentTo(firstSession))
-	AssetSessionCountEqualTo(g, simr, 1)
+	AssertSessionCountEqualTo(g, simr, 1)
 }
 
 func TestGetSessionWithKeepAliveTagManagerLogout(t *testing.T) {
@@ -182,17 +182,17 @@ func TestGetSessionWithKeepAliveTagManagerLogout(t *testing.T) {
 	s, err := session.GetOrCreate(context.Background(), params)
 	g.Expect(err).ToNot(gomega.HaveOccurred())
 	g.Expect(s).ToNot(gomega.BeNil())
-	AssetSessionCountEqualTo(g, simr, 1)
+	AssertSessionCountEqualTo(g, simr, 1)
 	sessionInfo, err := s.SessionManager.UserSession(context.Background())
 	g.Expect(err).ToNot(gomega.HaveOccurred())
 	g.Expect(sessionInfo).ToNot(gomega.BeNil())
 	sessionKey := sessionInfo.Key
-	AssetSessionCountEqualTo(g, simr, 1)
+	AssertSessionCountEqualTo(g, simr, 1)
 
 	// wait enough time so the session is expired
 	// as KeepAliveDuration 2 seconds > SessionIdleTimeout 1 second
 	time.Sleep(5 * time.Second)
-	AssetSessionCountEqualTo(g, simr, 0)
+	AssertSessionCountEqualTo(g, simr, 0)
 
 	// Get session again
 	// as session is deleted we must get new session
@@ -205,12 +205,12 @@ func TestGetSessionWithKeepAliveTagManagerLogout(t *testing.T) {
 	g.Expect(sessionInfo).ToNot(gomega.BeNil())
 	g.Expect(sessionInfo.Key).ToNot(gomega.BeEquivalentTo(sessionKey))
 	sessionKey = sessionInfo.Key
-	AssetSessionCountEqualTo(g, simr, 1)
+	AssertSessionCountEqualTo(g, simr, 1)
 
 	// wait enough time so the session is expired
 	// as KeepAliveDuration 2 seconds > SessionIdleTimeout 1 second
 	time.Sleep(5 * time.Second)
-	AssetSessionCountEqualTo(g, simr, 0)
+	AssertSessionCountEqualTo(g, simr, 0)
 
 	s, err = session.GetOrCreate(context.Background(), params)
 	g.Expect(err).ToNot(gomega.HaveOccurred())
@@ -219,5 +219,5 @@ func TestGetSessionWithKeepAliveTagManagerLogout(t *testing.T) {
 	g.Expect(err).ToNot(gomega.HaveOccurred())
 	g.Expect(sessionInfo).ToNot(gomega.BeNil())
 	g.Expect(sessionInfo.Key).ToNot(gomega.BeEquivalentTo(sessionKey))
-	AssetSessionCountEqualTo(g, simr, 1)
+	AssertSessionCountEqualTo(g, simr, 1)
 }

--- a/pkg/session/session.go
+++ b/pkg/session/session.go
@@ -28,19 +28,21 @@ import (
 	"github.com/vmware/govmomi/find"
 	"github.com/vmware/govmomi/object"
 	"github.com/vmware/govmomi/session"
+	"github.com/vmware/govmomi/session/keepalive"
 	"github.com/vmware/govmomi/vapi/rest"
 	"github.com/vmware/govmomi/vapi/tags"
 	"github.com/vmware/govmomi/vim25"
 	"github.com/vmware/govmomi/vim25/methods"
 	"github.com/vmware/govmomi/vim25/soap"
+	"github.com/vmware/govmomi/vim25/types"
 	ctrl "sigs.k8s.io/controller-runtime"
 
 	"sigs.k8s.io/cluster-api-provider-vsphere/api/v1alpha4"
 	"sigs.k8s.io/cluster-api-provider-vsphere/pkg/constants"
 )
 
-var sessionCache = map[string]Session{}
-var sessionMU sync.Mutex
+var sessionCache sync.Map
+
 
 // Session is a vSphere session with a configured Finder.
 type Session struct {
@@ -104,25 +106,37 @@ func (p *Params) WithFeatures(feature Feature) *Params {
 // already exist.
 func GetOrCreate(ctx context.Context, params *Params) (*Session, error) {
 	logger := ctrl.LoggerFrom(ctx).WithName("session")
-	sessionMU.Lock()
-	defer sessionMU.Unlock()
 
 	sessionKey := params.server + params.userinfo.Username() + params.datacenter
-	if cachedSession, ok := sessionCache[sessionKey]; ok {
+	if cachedSession, ok := sessionCache.Load(sessionKey); ok {
+		s := cachedSession.(*Session)
 		logger = logger.WithValues("server", params.server, "datacenter", params.datacenter)
-		// if keepalive is enabled we depend upon roundtripper to reestablish the connection
-		// and remove the key if it could not
-		if params.feature.EnableKeepAlive {
-			return &cachedSession, nil
+
+		vimSessionActive, err := s.SessionManager.SessionIsActive(ctx)
+		if err != nil {
+			if soap.IsSoapFault(err) {
+				switch soap.ToSoapFault(err).VimFault().(type) {
+				case types.NotAuthenticated:
+				default:
+					return nil, err
+				}
+			} else {
+				return nil, err
+			}
 		}
-		var err error
-		if ok, err = cachedSession.SessionManager.SessionIsActive(ctx); ok {
+
+		tagManagerSession, err := s.TagManager.Session(ctx)
+		if err != nil {
+			return nil, err
+		}
+
+		if vimSessionActive && tagManagerSession != nil {
 			logger.V(2).Info("found active cached vSphere client session")
-			return &cachedSession, nil
+			return s, nil
 		}
-		logger.V(2).Error(err, "error checking if session is active")
 	}
 
+	clearCache(logger, sessionKey)
 	soapURL, err := soap.ParseURL(params.server)
 	if err != nil {
 		return nil, errors.Wrapf(err, "error parsing vSphere URL %q", params.server)
@@ -143,7 +157,7 @@ func GetOrCreate(ctx context.Context, params *Params) (*Session, error) {
 	// Assign the finder to the session.
 	session.Finder = find.NewFinder(session.Client.Client, false)
 	// Assign tag manager to the session.
-	manager, err := newManager(ctx, client.Client, soapURL.User)
+	manager, err := newManager(ctx, logger, sessionKey, client.Client, soapURL.User, params.feature)
 	if err != nil {
 		return nil, errors.Wrap(err, "unable to create tags manager")
 	}
@@ -160,7 +174,7 @@ func GetOrCreate(ctx context.Context, params *Params) (*Session, error) {
 	}
 
 	// Cache the session.
-	sessionCache[sessionKey] = session
+	sessionCache.Store(sessionKey, &session)
 
 	logger.V(2).Info("cached vSphere client session", "server", params.server, "datacenter", params.datacenter)
 
@@ -195,7 +209,7 @@ func newClient(ctx context.Context, logger logr.Logger, sessionKey string, url *
 			_, err := methods.GetCurrentTime(ctx, tripper)
 			if err != nil {
 				logger.Error(err, "failed to keep alive govmomi client")
-				clearCache(sessionKey)
+				clearCache(logger, sessionKey)
 			}
 			return err
 		})
@@ -208,15 +222,56 @@ func newClient(ctx context.Context, logger logr.Logger, sessionKey string, url *
 	return c, nil
 }
 
-func clearCache(sessionKey string) {
-	sessionMU.Lock()
-	defer sessionMU.Unlock()
-	delete(sessionCache, sessionKey)
+func clearCache(logger logr.Logger, sessionKey string) {
+	if cachedSession, ok := sessionCache.Load(sessionKey); ok {
+		s := cachedSession.(*Session)
+		session, err := s.TagManager.Session(context.Background())
+		if err != nil {
+			logger.Error(err, "unable to get tag manager session")
+		}
+		if session != nil {
+			logger.Info("found active tag manager session, logging out")
+			err := s.TagManager.Logout(context.Background())
+			if err != nil {
+				logger.Error(err, "unable to logout tag manager session")
+			}
+		}
+
+		vimSessionActive, err := s.SessionManager.SessionIsActive(context.Background())
+		if err != nil {
+			logger.Error(err, "unable to get vim client session")
+		} else {
+			if vimSessionActive {
+				logger.Info("found active vim session, logging out")
+				err := s.SessionManager.Logout(context.Background())
+				if err != nil {
+					logger.Error(err, "unable to logout vim session")
+				}
+			}
+		}
+	}
+
+	sessionCache.Delete(sessionKey)
 }
 
 // newManager creates a Manager that encompasses the REST Client for the VSphere tagging API
-func newManager(ctx context.Context, client *vim25.Client, user *url.Userinfo) (*tags.Manager, error) {
+func newManager(ctx context.Context, logger logr.Logger, sessionKey string, client *vim25.Client, user *url.Userinfo, feature Feature) (*tags.Manager, error) {
 	rc := rest.NewClient(client)
+	if feature.EnableKeepAlive {
+		rc.Transport = keepalive.NewHandlerREST(rc, feature.KeepAliveDuration, func() error {
+			s, err := rc.Session(ctx)
+			if err != nil {
+				return err
+			}
+			if s != nil {
+				return nil
+			}
+
+			logger.Info("rest client session expired, clearing cache")
+			clearCache(logger, sessionKey)
+			return nil
+		})
+	}
 	err := rc.Login(ctx, user)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Base on https://github.com/kubernetes-sigs/cluster-api-provider-vsphere/pull/1336

tested with static ip cluster 