### PR TITLE
PCP-7232: Bump Go to 1.26.5

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -62,8 +62,8 @@ jobs:
         name: Build Image
         env:
           DEV_REGISTRY: ${{ env.LEGACY_REGISTRY }}
-          GO_VERSION: 1.26.4
-          BUILDER_GOLANG_VERSION: 1.26.4
+          GO_VERSION: 1.26.5
+          BUILDER_GOLANG_VERSION: 1.26.5
         run: |
           make docker-build
           make docker-push-gcr
@@ -73,8 +73,8 @@ jobs:
           FIPS_ENABLE: yes
           DEV_REGISTRY: ${{ env.FIPS_REGISTRY }}
           ALL_ARCH: amd64
-          GO_VERSION: 1.26.4
-          BUILDER_GOLANG_VERSION: 1.26.4
+          GO_VERSION: 1.26.5
+          BUILDER_GOLANG_VERSION: 1.26.5
         run: |
           make docker-build
           make docker-push-gcr

--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ SHELL:=/usr/bin/env bash
 #
 # Go.
 #
-GO_VERSION ?= 1.26.4
+GO_VERSION ?= 1.26.5
 GO_DIRECTIVE_VERSION ?= 1.26.0
 GO_CONTAINER_IMAGE ?= docker.io/library/golang:$(GO_VERSION)
 
@@ -271,7 +271,7 @@ ifeq ($(FIPS_ENABLE),yes)
   RELEASE_LOC := release-fips
 endif
 
-BUILDER_GOLANG_VERSION ?= 1.26.4
+BUILDER_GOLANG_VERSION ?= 1.26.5
 BUILD_ARGS = --build-arg CRYPTO_LIB=${FIPS_ENABLE} --build-arg BUILDER_GOLANG_VERSION=${BUILDER_GOLANG_VERSION}
 
 SPECTRO_VERSION ?= 4.0.0-dev


### PR DESCRIPTION
Upgrade GO_VERSION, BUILDER_GOLANG_VERSION, and go directives from 1.26.4/1.26.0 to 1.26.5 for CAPV image rebuilds.